### PR TITLE
공통 컴포넌트 - Input 제작

### DIFF
--- a/components/commonInput/input.module.scss
+++ b/components/commonInput/input.module.scss
@@ -1,0 +1,33 @@
+@use '@/styles/utils';
+
+.inputWrapper {
+  width: 100%;
+}
+
+.inputTextField {
+  width: 100%;
+  margin: 0;
+  border: 0;
+  border-bottom: 1px solid $dark-grey;
+  outline: none;
+  @include utils.font-style('button1');
+}
+
+.large {
+  font-size: 17px;
+  font-weight: 400;
+  letter-spacing: 0.5px;
+  line-height: 24px; /* 141.176% */
+}
+
+.medium {
+  font-size: 14px;
+  font-style: normal;
+  font-weight: 400;
+  letter-spacing: -0.3px;
+  line-height: 27px; /* 192.857% */
+}
+
+.small {
+  font-size: 11px;
+}

--- a/components/commonInput/input.stories.tsx
+++ b/components/commonInput/input.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from '@storybook/react'
+
+import { Input } from './input'
+
+const meta: Meta<typeof Input.TextField> = {
+  title: 'Input',
+  component: Input.TextField,
+}
+export default meta
+type Story = StoryObj<typeof Input>
+
+export const Empty: Story = {
+  args: {},
+}
+
+export const Small: Story = {
+  args: {
+    placeholder: 'small이어요',
+    size: 'small',
+    onChange: () => console.log('small'),
+  },
+}
+
+export const Medium: Story = {
+  args: {
+    placeholder: 'medium입니다.',
+    size: 'medium',
+    onChange: () => console.log('medium'),
+  },
+}
+
+export const Large: Story = {
+  args: {
+    placeholder: 'large입니다.',
+    size: 'large',
+    onChange: () => console.log('large'),
+  },
+}

--- a/components/commonInput/input.stories.tsx
+++ b/components/commonInput/input.stories.tsx
@@ -1,39 +1,32 @@
 import type { Meta, StoryObj } from '@storybook/react'
 
 import { Input } from './input'
+import { TextField } from './inputTextField.stories'
 
-const meta: Meta<typeof Input.TextField> = {
+const meta: Meta<typeof Input> = {
   title: 'Input',
-  component: Input.TextField,
+  component: Input,
 }
 export default meta
 
 type Story = StoryObj<typeof Input>
 
-export const Empty: Story = {
-  args: {},
-}
-
 export const Small: Story = {
   args: {
-    placeholder: 'small이어요',
     variant: 'small',
-    onChange: () => console.log('small'),
+    children: <Input.TextField {...TextField.args} />,
   },
 }
 
 export const Medium: Story = {
   args: {
-    placeholder: 'medium입니다.',
     variant: 'medium',
-    onChange: () => console.log('medium'),
+    children: <Input.TextField {...TextField.args} />,
   },
 }
-
 export const Large: Story = {
   args: {
-    placeholder: 'large입니다.',
     variant: 'large',
-    onChange: () => console.log('large'),
+    children: <Input.TextField {...TextField.args} />,
   },
 }

--- a/components/commonInput/input.stories.tsx
+++ b/components/commonInput/input.stories.tsx
@@ -7,6 +7,7 @@ const meta: Meta<typeof Input.TextField> = {
   component: Input.TextField,
 }
 export default meta
+
 type Story = StoryObj<typeof Input>
 
 export const Empty: Story = {
@@ -16,7 +17,7 @@ export const Empty: Story = {
 export const Small: Story = {
   args: {
     placeholder: 'small이어요',
-    size: 'small',
+    variant: 'small',
     onChange: () => console.log('small'),
   },
 }
@@ -24,7 +25,7 @@ export const Small: Story = {
 export const Medium: Story = {
   args: {
     placeholder: 'medium입니다.',
-    size: 'medium',
+    variant: 'medium',
     onChange: () => console.log('medium'),
   },
 }
@@ -32,7 +33,7 @@ export const Medium: Story = {
 export const Large: Story = {
   args: {
     placeholder: 'large입니다.',
-    size: 'large',
+    variant: 'large',
     onChange: () => console.log('large'),
   },
 }

--- a/components/commonInput/input.tsx
+++ b/components/commonInput/input.tsx
@@ -9,8 +9,6 @@ import React, {
 
 import classNames from 'classnames/bind'
 
-import { gmarketSans } from '@/styles/local.fonts'
-
 import styles from './input.module.scss'
 import { TextFeildProps } from './input.types'
 
@@ -25,7 +23,7 @@ export function Input({ children, variant }: InputProps) {
   const child = Children.only(children)
 
   return (
-    <div className={cx('inputWrapper', gmarketSans.className)}>
+    <div className={cx('inputWrapper')}>
       {cloneElement(child, {
         className: cx('inputTextField', [variant]),
         ...child.props,

--- a/components/commonInput/input.tsx
+++ b/components/commonInput/input.tsx
@@ -1,0 +1,52 @@
+import React, {
+  Children,
+  ForwardedRef,
+  HTMLAttributes,
+  InputHTMLAttributes,
+  ReactElement,
+  cloneElement,
+  forwardRef,
+} from 'react'
+
+import classNames from 'classnames/bind'
+
+import { gmarketSans } from '@/styles/local.fonts'
+
+import styles from './input.module.scss'
+
+const cx = classNames.bind(styles)
+
+interface InputProps extends HTMLAttributes<HTMLDivElement> {
+  children: ReactElement
+  size: string
+}
+
+export function Input({ children, size }: InputProps) {
+  const child = Children.only(children)
+
+  return (
+    <div className={cx('inputWrapper', gmarketSans.className)}>
+      {cloneElement(child, {
+        className: cx('inputTextField', [size]),
+        ...child.props,
+      })}
+    </div>
+  )
+}
+
+type TextFieldProps = InputHTMLAttributes<HTMLInputElement>
+
+Input.TextField = forwardRef(function TextField(
+  { onChange, size, ...props }: TextFieldProps,
+  ref: ForwardedRef<HTMLInputElement>,
+) {
+  return (
+    <input
+      className={cx('inputTextField')}
+      ref={ref}
+      onChange={onChange}
+      size={size}
+      {...props}
+    />
+  )
+})

--- a/components/commonInput/input.tsx
+++ b/components/commonInput/input.tsx
@@ -18,16 +18,16 @@ const cx = classNames.bind(styles)
 
 interface InputProps extends HTMLAttributes<HTMLDivElement> {
   children: ReactElement
-  size: string
+  variant: string
 }
 
-export function Input({ children, size }: InputProps) {
+export function Input({ children, variant }: InputProps) {
   const child = Children.only(children)
 
   return (
     <div className={cx('inputWrapper', gmarketSans.className)}>
       {cloneElement(child, {
-        className: cx('inputTextField', [size]),
+        className: cx('inputTextField', [variant]),
         ...child.props,
       })}
     </div>
@@ -35,8 +35,15 @@ export function Input({ children, size }: InputProps) {
 }
 
 Input.TextField = forwardRef(function TextField(
-  { size, ...props }: TextFeildProps,
+  { onChange, ...props }: TextFeildProps,
   ref: ForwardedRef<HTMLInputElement>,
 ) {
-  return <input className={cx('inputTextField', [size])} ref={ref} {...props} />
+  return (
+    <input
+      className={cx('inputTextField', [props.variant])}
+      ref={ref}
+      onChange={onChange}
+      {...props}
+    />
+  )
 })

--- a/components/commonInput/input.tsx
+++ b/components/commonInput/input.tsx
@@ -29,6 +29,7 @@ export function Input({ children, variant }: InputProps) {
       {cloneElement(child, {
         className: cx('inputTextField', [variant]),
         ...child.props,
+        variant,
       })}
     </div>
   )
@@ -40,7 +41,7 @@ Input.TextField = forwardRef(function TextField(
 ) {
   return (
     <input
-      className={cx('inputTextField', [props.variant])}
+      className={cx('inputTextField')}
       ref={ref}
       onChange={onChange}
       {...props}

--- a/components/commonInput/input.tsx
+++ b/components/commonInput/input.tsx
@@ -2,7 +2,6 @@ import React, {
   Children,
   ForwardedRef,
   HTMLAttributes,
-  InputHTMLAttributes,
   ReactElement,
   cloneElement,
   forwardRef,
@@ -13,6 +12,7 @@ import classNames from 'classnames/bind'
 import { gmarketSans } from '@/styles/local.fonts'
 
 import styles from './input.module.scss'
+import { TextFeildProps } from './input.types'
 
 const cx = classNames.bind(styles)
 
@@ -34,19 +34,9 @@ export function Input({ children, size }: InputProps) {
   )
 }
 
-type TextFieldProps = InputHTMLAttributes<HTMLInputElement>
-
 Input.TextField = forwardRef(function TextField(
-  { onChange, size, ...props }: TextFieldProps,
+  { size, ...props }: TextFeildProps,
   ref: ForwardedRef<HTMLInputElement>,
 ) {
-  return (
-    <input
-      className={cx('inputTextField')}
-      ref={ref}
-      onChange={onChange}
-      size={size}
-      {...props}
-    />
-  )
+  return <input className={cx('inputTextField', [size])} ref={ref} {...props} />
 })

--- a/components/commonInput/input.types.ts
+++ b/components/commonInput/input.types.ts
@@ -15,6 +15,5 @@ export type ChangeHandler = (e: React.ChangeEvent) => void
 
 export interface TextFeildProps
   extends Omit<InputHTMLAttributes<HTMLInputElement>, 'size'> {
-  variant: string
   onChange?: ChangeHandler
 }

--- a/components/commonInput/input.types.ts
+++ b/components/commonInput/input.types.ts
@@ -1,0 +1,20 @@
+import { InputHTMLAttributes } from 'react'
+
+/**
+ * 버튼 타입 enum입니다.
+ * @DEACTIVE 비활성화 버튼
+ * @ACTIVE 활성화 버튼
+ */
+export enum InputStyle {
+  SMALL = 'small',
+  MEDIUM = 'medium',
+  LARGE = 'large',
+}
+
+export type ChangeHandler = (e: React.ChangeEvent) => void
+
+export interface TextFeildProps
+  extends Omit<InputHTMLAttributes<HTMLInputElement>, 'size'> {
+  size: InputStyle
+  onChange?: ChangeHandler
+}

--- a/components/commonInput/input.types.ts
+++ b/components/commonInput/input.types.ts
@@ -15,6 +15,6 @@ export type ChangeHandler = (e: React.ChangeEvent) => void
 
 export interface TextFeildProps
   extends Omit<InputHTMLAttributes<HTMLInputElement>, 'size'> {
-  size: InputStyle
+  variant: string
   onChange?: ChangeHandler
 }

--- a/components/commonInput/inputTextField.stories.tsx
+++ b/components/commonInput/inputTextField.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from '@storybook/react'
+
+import { Input } from './input'
+
+const meta: Meta<typeof Input.TextField> = {
+  title: 'Input/TextField',
+  component: Input.TextField,
+}
+export default meta
+
+type Story = StoryObj<typeof Input.TextField>
+
+export const Empty: Story = {
+  args: {},
+}
+
+export const TextField: Story = {
+  args: {
+    placeholder: 'placeholder입니다',
+    onChange: () => console.log('small'),
+  },
+}

--- a/styles/local.fonts.ts
+++ b/styles/local.fonts.ts
@@ -8,7 +8,7 @@ export const gmarketSans = localFont({
       style: 'normal',
     },
     {
-      path: '../public/fdonts/GmarketSansMedium.woff',
+      path: '../public/fonts/GmarketSansMedium.woff',
       weight: '400',
       style: 'normal',
     },


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

<!-- 해당되는 사항만 남기고 나머지 줄을 삭제해주세요 -->

- FEAT : 새로운 기능 추가 및 개선
- FIX : 버그 수정

## 설명
공통컴포넌트인 input을 제작했습니다.
추가적으로 local.fonts의 경로가 잘못된 부분은 hotfix이지만 함께 수정했습니다


### 이슈 번호

<!-- 키워드를 사용해 이슈를 연결해주세요 -->
<!-- 예시: close #1 / closes #1, #3 / resolve #4 -->
close #38 


### Key Changes

- input component 제작
- input storybook 제작


### How it Works
```
      <Input variant="small">
        <Input.TextField
          onChange={() => console.log('small')}
          placeholder="하이루"
        />
      </Input>
```
Input으로 Input.TextField를 감싸면 되고, Input은 하나의 자식만을 가져야합니다.
InputField의 사이즈는 Input의 variant를 따릅니다.


### To Reviewers

- 우선 onChange를 넘겨주는 컴포넌트로 제작했습니다. 컴포넌트 구조 회의한 후 수정해야할 것 같습니다.
- storybook에는 Input이 아닌 Input.TextField의 스토리가 담겨져있습니다. props를 보여주기 위해 그렇게 했는데, 봐주세요
