### PR TITLE
Fab 버튼 구현(PC)

### DIFF
--- a/components/fab/circleButton.module.scss
+++ b/components/fab/circleButton.module.scss
@@ -7,18 +7,18 @@
 }
 
 .sm {
+  width: 50px;
+  height: 50px;
+}
+
+.md {
   width: 60px;
   height: 60px;
 }
 
-.md {
+.lg {
   width: 70px;
   height: 70px;
-}
-
-.lg {
-  width: 90px;
-  height: 90px;
 }
 
 .blank {

--- a/components/fab/fab.module.scss
+++ b/components/fab/fab.module.scss
@@ -1,0 +1,26 @@
+.fab {
+  display: flex;
+  position: fixed;
+  right: 130px;
+  bottom: 160px;
+  flex-direction: column;
+  align-items: center;
+  gap: 24px;
+}
+
+.basic {
+  width: 70px;
+  height: 70px;
+}
+
+.buttons {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.mdButtons {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}

--- a/components/fab/fab.stories.tsx
+++ b/components/fab/fab.stories.tsx
@@ -1,0 +1,15 @@
+import type { Meta, StoryObj } from '@storybook/react'
+
+import Fab from './fab'
+
+const fab: Meta<typeof Fab> = {
+  title: 'Components/Fab',
+  component: Fab,
+}
+
+export default fab
+type Story = StoryObj<typeof Fab>
+
+export const Default: Story = {
+  args: {},
+}

--- a/components/fab/fab.tsx
+++ b/components/fab/fab.tsx
@@ -1,0 +1,71 @@
+import { useState } from 'react'
+
+import classNames from 'classnames/bind'
+import { motion } from 'framer-motion'
+
+import CircleButton from '@/components/fab/circleButton'
+
+import styles from './fab.module.scss'
+
+const cx = classNames.bind(styles)
+
+export default function Fab() {
+  const [isClicked, setIsClicked] = useState(false)
+
+  const handleClick = () => {
+    setIsClicked(!isClicked)
+  }
+
+  return (
+    <div className={cx('fab')}>
+      {isClicked && (
+        <motion.div
+          // initial={{ opacity: 0, y: -10 }}
+          // animate={{ opacity: 1, y: 0 }}
+          // exit={{ opacity: 0, y: -10, transition: { duration: 0.3 } }}
+          className={cx('buttons')}
+        >
+          <div>
+            <div
+              style={{ position: 'absolute', bottom: '52px', right: '94px' }}
+            >
+              <CircleButton name="facebook" image="facebook" size="sm" />
+            </div>
+            <div
+              style={{ position: 'absolute', bottom: '110px', right: '94px' }}
+            >
+              <CircleButton name="kakao" image="kakao" size="sm" />
+            </div>
+            <div
+              style={{ position: 'absolute', bottom: '165px', right: '71px' }}
+            >
+              <CircleButton name="instagram" image="instagram" size="sm" />
+            </div>
+            <div
+              style={{ position: 'absolute', bottom: '182px', right: '10px' }}
+            >
+              <CircleButton name="link" image="link" size="sm" />
+            </div>
+          </div>
+          <CircleButton
+            name="text"
+            text="꿀팁받기"
+            transparent={true}
+            size="md"
+          />
+        </motion.div>
+      )}
+      <motion.div
+        animate={{ rotate: isClicked ? 45 : 0 }}
+        className={cx('basic')}
+      >
+        <CircleButton
+          name="plus"
+          size="lg"
+          image="plus"
+          onClick={handleClick}
+        />
+      </motion.div>
+    </div>
+  )
+}

--- a/components/fab/fabForDf.stories.tsx
+++ b/components/fab/fabForDf.stories.tsx
@@ -1,0 +1,15 @@
+import type { Meta, StoryObj } from '@storybook/react'
+
+import FabForDf from './fabForDf'
+
+const fab: Meta<typeof FabForDf> = {
+  title: 'Components/FabForDf',
+  component: FabForDf,
+}
+
+export default fab
+type Story = StoryObj<typeof FabForDf>
+
+export const Default: Story = {
+  args: {},
+}

--- a/components/fab/fabForDf.tsx
+++ b/components/fab/fabForDf.tsx
@@ -1,0 +1,79 @@
+import { useState } from 'react'
+
+import classNames from 'classnames/bind'
+import { motion } from 'framer-motion'
+
+import CircleButton from '@/components/fab/circleButton'
+
+import styles from './fab.module.scss'
+
+const cx = classNames.bind(styles)
+
+export default function FabWithDef() {
+  const [isClicked, setIsClicked] = useState(false)
+
+  const handleClick = () => {
+    setIsClicked(!isClicked)
+  }
+
+  return (
+    <div className={cx('fab')}>
+      {isClicked && (
+        <motion.div
+          // initial={{ opacity: 0, y: -10 }}
+          // animate={{ opacity: 1, y: 0 }}
+          // // exit={{ opacity: 0, y: -10, transition: { duration: 0.3 } }}
+          className={cx('buttons')}
+        >
+          <div>
+            <div
+              style={{ position: 'absolute', bottom: '109px', right: '94px' }}
+            >
+              <CircleButton name="facebook" image="facebook" size="sm" />
+            </div>
+            <div
+              style={{ position: 'absolute', bottom: '174px', right: '94px' }}
+            >
+              <CircleButton name="kakao" image="kakao" size="sm" />
+            </div>
+            <div
+              style={{ position: 'absolute', bottom: '236px', right: '71px' }}
+            >
+              <CircleButton name="instagram" image="instagram" size="sm" />
+            </div>
+            <div
+              style={{ position: 'absolute', bottom: '261px', right: '10px' }}
+            >
+              <CircleButton name="link" image="link" size="sm" />
+            </div>
+          </div>
+          <div className={cx('mdButtons')}>
+            <CircleButton
+              name="text"
+              text="꿀팁받기"
+              transparent={true}
+              size="md"
+            />
+            <CircleButton
+              name="text"
+              text="단점보기"
+              transparent={true}
+              size="md"
+            />
+          </div>
+        </motion.div>
+      )}
+      <motion.div
+        animate={{ rotate: isClicked ? 45 : 0 }}
+        className={cx('basic')}
+      >
+        <CircleButton
+          name="plus"
+          size="lg"
+          image="plus"
+          onClick={handleClick}
+        />
+      </motion.div>
+    </div>
+  )
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@types/react-dom": "18.2.7",
         "classnames": "^2.3.2",
         "eslint-config-next": "13.4.12",
+        "framer-motion": "^10.15.1",
         "next": "13.4.12",
         "prettier": "^3.0.1",
         "react": "18.2.0",
@@ -2930,6 +2931,21 @@
       "engines": {
         "node": ">=10.0.0"
       }
+    },
+    "node_modules/@emotion/is-prop-valid": {
+      "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
+      "integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
+      "optional": true,
+      "dependencies": {
+        "@emotion/memoize": "0.7.4"
+      }
+    },
+    "node_modules/@emotion/memoize": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
+      "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
+      "optional": true
     },
     "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
       "version": "1.0.1",
@@ -13032,6 +13048,29 @@
       "dev": true,
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/framer-motion": {
+      "version": "10.15.1",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-10.15.1.tgz",
+      "integrity": "sha512-6avJj/Uftblw0fMmo6jDHkKRH4TBdkMX/FiyR3G/hFe3hQHE4BUNJCqlMPKg9EzfI5jyqDOwO5oDnU+bW5y0eg==",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      },
+      "optionalDependencies": {
+        "@emotion/is-prop-valid": "^0.8.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/fresh": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@types/react-dom": "18.2.7",
     "classnames": "^2.3.2",
     "eslint-config-next": "13.4.12",
+    "framer-motion": "^10.15.1",
     "next": "13.4.12",
     "prettier": "^3.0.1",
     "react": "18.2.0",


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

<!-- 해당되는 사항만 남기고 나머지 줄을 삭제해주세요 -->

- FEAT : 새로운 기능 추가 및 개선
- REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- CHORE : 패키지 매니저 설정, 코드 수정 없이 설정 변경(eslint) 등 기타 사항

## 설명
FAB 버튼의 PC 버전을 구현합니다.
JFF / DF 각각에 들어갈 FAB를 따로 구현하였습니다.
framer-motion과 각 버튼 positioning이 양립되지 않아서 문제 수정이 필요합니다.


### 이슈 번호

<!-- 키워드를 사용해 이슈를 연결해주세요 -->
<!-- 예시: close #1 / closes #1, #3 / resolve #4 -->
closes #15, #57 


### Key Changes

- FAB 버튼 구현
- FAB 내 각 버튼 위치 조정
- framer-motion 애니메이션 사용


### How it Works

- 간단한 로직 설명


### To Reviewers

- mobile 버전은 구현 예정입니다.
- 디자인 수정이 좀 잦아서 생각보다 늦게 되었습니다.
- 각 버튼들이 absolute-positioning 되어 있는데 transition 애니메이션을 사용할 때 너무 위에서 내려오는 문제가 있어서 수정 중에 있습니다. 일단 사용해 보고 애니메이션은 추후 수정되는 대로 반영하겠습니다.
- 버튼들을 포지셔닝 할때 class를 주지 않고 인라인 style로 일단 구현했습니다. class를 넘겨주게 되면 prop도 수정해야 할 것 같고, 포지션을 좀 직관적으로 확인하고 싶어서 인라인으로 일단 넣어두었습니다.
- DFF에 단점 버튼이 하나 더 들어가기 때문에 아예 서로 다른 버튼으로 구현했습니다. Position이 완전히 달라져서 따로 제작하는 것이 좋을 것 같다는 생각입니다.
