### PR TITLE
Feature/implement modal layout/#59

### DIFF
--- a/components/modalLayout/characterModalLayout.module.scss
+++ b/components/modalLayout/characterModalLayout.module.scss
@@ -1,0 +1,27 @@
+.modal {
+  width: 1080px;
+  height: 588px;
+  margin: 106px auto 0;
+  padding: 44px 50px 0;
+  border: 1px solid black;
+  border-radius: 20px;
+}
+
+.header {
+  @include flexbox(row, space-between, center);
+
+  width: 975px;
+  margin-bottom: 12px;
+}
+
+.title {
+  @include font-style('text4');
+}
+
+.contents {
+  width: 970px;
+
+  @include flexbox(row, center, center);
+
+  gap: 70px;
+}

--- a/components/modalLayout/characterModalLayout.module.scss
+++ b/components/modalLayout/characterModalLayout.module.scss
@@ -11,6 +11,7 @@
   @include flexbox(row, space-between, center);
 
   width: 975px;
+  margin: 0 auto;
   margin-bottom: 12px;
 }
 
@@ -23,5 +24,6 @@
 
   @include flexbox(row, center, center);
 
+  margin: 0 auto;
   gap: 70px;
 }

--- a/components/modalLayout/characterModalLayout.module.scss
+++ b/components/modalLayout/characterModalLayout.module.scss
@@ -1,6 +1,5 @@
 .modal {
   width: 1080px;
-  height: 588px;
   margin: 106px auto 0;
   padding: 44px 50px 0;
   border: 1px solid black;

--- a/components/modalLayout/characterModalLayout.stories.tsx
+++ b/components/modalLayout/characterModalLayout.stories.tsx
@@ -1,0 +1,20 @@
+import type { Meta, StoryObj } from '@storybook/react'
+
+import CharacterModalLayout from './characterModalLayout'
+
+const characterModal: Meta<typeof CharacterModalLayout> = {
+  title: 'ModalLayout/CharacterModalLayout',
+  component: CharacterModalLayout,
+}
+
+export default characterModal
+type Story = StoryObj<typeof CharacterModalLayout>
+
+export const Default: Story = {
+  args: {
+    title: '자신이 다시 꾸미기',
+    closeBtn: <button>X</button>,
+    character: <div>Character</div>,
+    content: <div>Content</div>,
+  },
+}

--- a/components/modalLayout/characterModalLayout.tsx
+++ b/components/modalLayout/characterModalLayout.tsx
@@ -1,0 +1,26 @@
+import classNames from 'classnames/bind'
+
+import styles from './characterModalLayout.module.scss'
+import { CharacterModalLayoutProps } from './characterModalLayout.types'
+
+const cx = classNames.bind(styles)
+
+export default function CharacterModalLayout({
+  title,
+  closeBtn,
+  character,
+  content,
+}: CharacterModalLayoutProps) {
+  return (
+    <div className={cx('modal')}>
+      <div className={cx('header')}>
+        <p className={cx('title')}>{title}</p>
+        {closeBtn}
+      </div>
+      <div className={cx('contents')}>
+        {character}
+        {content}
+      </div>
+    </div>
+  )
+}

--- a/components/modalLayout/characterModalLayout.types.ts
+++ b/components/modalLayout/characterModalLayout.types.ts
@@ -1,0 +1,6 @@
+export interface CharacterModalLayoutProps {
+  title: string
+  closeBtn: React.ReactNode
+  character: React.ReactNode
+  content: React.ReactNode
+}

--- a/components/modalLayout/contentModalLayout.module.scss
+++ b/components/modalLayout/contentModalLayout.module.scss
@@ -1,0 +1,29 @@
+.modal {
+  width: 1080px;
+  height: 588px;
+  margin: 106px auto 0;
+  padding: 44px 50px 0;
+  border: 1px solid black;
+  border-radius: 20px;
+}
+
+.header {
+  @include flexbox(row, space-between, center);
+
+  width: 975px;
+  margin-bottom: 52px;
+}
+
+.title {
+  @include font-style('text4');
+}
+
+.contents {
+  width: 791px;
+  margin: 0 auto;
+  @include flexbox(column, center);
+}
+
+.content {
+  margin-bottom: 81px;
+}

--- a/components/modalLayout/contentModalLayout.module.scss
+++ b/components/modalLayout/contentModalLayout.module.scss
@@ -11,6 +11,7 @@
   @include flexbox(row, space-between, center);
 
   width: 975px;
+  margin: 0 auto;
   margin-bottom: 52px;
 }
 

--- a/components/modalLayout/contentModalLayout.module.scss
+++ b/components/modalLayout/contentModalLayout.module.scss
@@ -1,6 +1,5 @@
 .modal {
   width: 1080px;
-  height: 588px;
   margin: 106px auto 0;
   padding: 44px 50px 0;
   border: 1px solid black;

--- a/components/modalLayout/contentModalLayout.stories.tsx
+++ b/components/modalLayout/contentModalLayout.stories.tsx
@@ -1,0 +1,21 @@
+import type { Meta, StoryObj } from '@storybook/react'
+
+import CommonBtn from '../commonBtn/commonBtn'
+import ContentModalLayout from './contentModalLayout'
+
+const contentModal: Meta<typeof ContentModalLayout> = {
+  title: 'ModalLayout/ContentModalLayout',
+  component: ContentModalLayout,
+}
+
+export default contentModal
+type Story = StoryObj<typeof ContentModalLayout>
+
+export const Default: Story = {
+  args: {
+    title: '자신이 다시 꾸미기',
+    closeBtn: <button>X</button>,
+    content: <div>Content</div>,
+    completeBtn: <CommonBtn>완료</CommonBtn>,
+  },
+}

--- a/components/modalLayout/contentModalLayout.tsx
+++ b/components/modalLayout/contentModalLayout.tsx
@@ -1,0 +1,26 @@
+import classNames from 'classnames/bind'
+
+import styles from './contentModalLayout.module.scss'
+import { ContentModalLayoutProps } from './contentModalLayout.types'
+
+const cx = classNames.bind(styles)
+
+export default function ContentModalLayout({
+  title,
+  closeBtn,
+  content,
+  completeBtn,
+}: ContentModalLayoutProps) {
+  return (
+    <div className={cx('modal')}>
+      <div className={cx('header')}>
+        <p className={cx('title')}>{title}</p>
+        {closeBtn}
+      </div>
+      <div className={cx('contents')}>
+        <div className={cx('content')}>{content}</div>
+        <div>{completeBtn}</div>
+      </div>
+    </div>
+  )
+}

--- a/components/modalLayout/contentModalLayout.types.ts
+++ b/components/modalLayout/contentModalLayout.types.ts
@@ -1,0 +1,6 @@
+export interface ContentModalLayoutProps {
+  title: string
+  content: React.ReactNode
+  closeBtn: React.ReactNode
+  completeBtn: React.ReactNode
+}

--- a/components/modalLayout/modalLayout.module.scss
+++ b/components/modalLayout/modalLayout.module.scss
@@ -1,6 +1,5 @@
 .modal {
   width: 1080px;
-  height: 588px;
   margin: 106px auto 0;
   border: 1px solid black;
   border-radius: 20px;

--- a/components/modalLayout/modalLayout.module.scss
+++ b/components/modalLayout/modalLayout.module.scss
@@ -1,0 +1,53 @@
+.modal {
+  width: 1080px;
+  height: 588px;
+  margin: 106px auto 0;
+  border: 1px solid black;
+  border-radius: 20px;
+}
+
+.character {
+  padding: 44px 50px 0;
+}
+
+.noCharacter {
+  padding: 44px 50px 0;
+}
+
+.header {
+  @include flexbox(row, space-between, center);
+
+  width: 975px;
+}
+
+.narrow {
+  margin-bottom: 12px;
+}
+
+.wide {
+  margin-bottom: 52px;
+}
+
+.title {
+  @include font-style('text4');
+}
+
+.yes {
+  width: 970px;
+
+  @include flexbox(row, center, center);
+
+  gap: 70px;
+}
+
+.no {
+  width: 791px;
+  margin: 0 auto;
+  @include flexbox(column, center);
+}
+
+.complete {
+  width: 791px;
+  margin: 0 auto;
+  margin-top: 81px;
+}

--- a/components/modalLayout/modalLayout.module.scss
+++ b/components/modalLayout/modalLayout.module.scss
@@ -18,6 +18,7 @@
   @include flexbox(row, space-between, center);
 
   width: 975px;
+  margin: 0 auto;
 }
 
 .narrow {
@@ -30,6 +31,10 @@
 
 .title {
   @include font-style('text4');
+}
+
+.contents {
+  margin: 0 auto;
 }
 
 .yes {

--- a/components/modalLayout/modalLayout.stories.tsx
+++ b/components/modalLayout/modalLayout.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from '@storybook/react'
+
+import CommonBtn from '../commonBtn/commonBtn'
+import ModalLayout from './modalLayout'
+
+const contentModal: Meta<typeof ModalLayout> = {
+  title: 'ModalLayout/ModalLayout',
+  component: ModalLayout,
+}
+
+export default contentModal
+type Story = StoryObj<typeof ModalLayout>
+
+export const Content: Story = {
+  args: {
+    title: '자신이 다시 꾸미기',
+    closeBtn: <button>X</button>,
+    content: <div>Content</div>,
+    completeBtn: <CommonBtn>완료</CommonBtn>,
+  },
+}
+
+export const Character: Story = {
+  args: {
+    title: '자신이 다시 꾸미기',
+    closeBtn: <button>X</button>,
+    content: <div>Content</div>,
+    character: <div>Character</div>,
+  },
+}

--- a/components/modalLayout/modalLayout.tsx
+++ b/components/modalLayout/modalLayout.tsx
@@ -1,0 +1,28 @@
+import classNames from 'classnames/bind'
+
+import styles from './modalLayout.module.scss'
+import { ModalLayoutProps } from './modalLayout.types'
+
+const cx = classNames.bind(styles)
+
+export default function ModalLayout({
+  title,
+  closeBtn,
+  character,
+  content,
+  completeBtn,
+}: ModalLayoutProps) {
+  return (
+    <div className={cx('modal', character ? 'character' : 'noCharacter')}>
+      <div className={cx('header', character ? 'narrow' : 'wide')}>
+        <p className={cx('title')}>{title}</p>
+        {closeBtn}
+      </div>
+      <div className={cx('contents', character ? 'yes' : 'no')}>
+        {character && character}
+        {content}
+      </div>
+      <div className={cx('complete')}>{completeBtn}</div>
+    </div>
+  )
+}

--- a/components/modalLayout/modalLayout.types.ts
+++ b/components/modalLayout/modalLayout.types.ts
@@ -1,0 +1,7 @@
+export interface ModalLayoutProps {
+  title: string
+  closeBtn: React.ReactNode
+  character?: React.ReactNode
+  content: React.ReactNode
+  completeBtn?: React.ReactNode
+}


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

<!-- 해당되는 사항만 남기고 나머지 줄을 삭제해주세요 -->

- FEAT : 새로운 기능 추가 및 개선

## 설명
마이페이지의 편집 모달 PC 레이아웃입니다.


### 이슈 번호

<!-- 키워드를 사용해 이슈를 연결해주세요 -->
<!-- 예시: close #1 / closes #1, #3 / resolve #4 -->
close #59 


### Key Changes

- 편집 모달 PC 레이아웃을 구현했습니다.
- ModalLayout / CharacterModalLayout / ContentModalLayout 세 가지 종류로 구현을 하였습니다.
- ModalLayout의 경우 character prop의 유무에 따라 배치가 변경될 수 있도록 구현하였고,
- Character~ / Content~ 레이아웃의 경우 각 경우를 분리하여 구현한 파일입니다.
- 즉, ModalLayout은 캐릭터와 그 외 컨텐츠 모달을 한 레이아웃으로 사용할 수 있도록 한 것이고, 나머지는 2가지 경우에 대한 레이아웃을 분리해 둔 파일입니다.
- 레이아웃을 구현하다 보니, 캐릭터 수정과 그 외(내용, 그래프) 수정 모달은 레이아웃 자체가 달라 한 레이아웃으로 묶는게 어색하다고 보아서 합쳐진 레이아웃, 각각 나누어진 레이아웃 모두를 만들어 두었습니다.


### How it Works
```
// ModalLayout prop
interface ModalLayoutProps {
  title: string // 모달 제목
  closeBtn: React.ReactNode // 모달 닫힘 버튼
  character?: React.ReactNode // 캐릭터 이미지 나오는 상자
  content: React.ReactNode // 이 외 컨텐츠가 들어갈 상자
  completeBtn?: React.ReactNode // 완료 버튼
}
```

```
// CharacterLayout prop
interface CharacterModalLayoutProps {
  title: string // 모달 제목
  closeBtn: React.ReactNode // 모달 닫힘 버튼
  character: React.ReactNode // 캐릭터 이미지 나오는 상자
  content: React.ReactNode // 캐릭터 아이템 선택 상자
}
```

```
// ContentLayout prop
interface ContentModalLayoutProps {
  title: string // 모달 제목
  content: React.ReactNode // 컨텐츠 (설명서, 그래프)
  closeBtn: React.ReactNode // 모달 닫힘 버튼
  completeBtn: React.ReactNode // 완료 버튼
}
```

### To Reviewers

- Key Changes에 작성되어 있는 부분을 읽어보시고, 2가지 경우 중 하나를 선택해서 파일을 남겨두면 좋을 것 같습니다.
- 의견 주시면 불필요한 파일 삭제하여 PR 올리겠습니다.
