### PR TITLE
마이페이지 내 질답 card 컴포넌트 구현

### DIFF
--- a/components/descriptionCard/descriptionCard.module.scss
+++ b/components/descriptionCard/descriptionCard.module.scss
@@ -15,8 +15,8 @@
   position: absolute;
   top: 24px;
   right: 15px;
-  width: 100px;
   height: 30px;
+  padding: 5.5px 15.5px;
   border: 0.75px solid $dark-grey;
   border-radius: 37.58px;
   @include font-style('text5');

--- a/components/descriptionCard/descriptionCard.module.scss
+++ b/components/descriptionCard/descriptionCard.module.scss
@@ -1,0 +1,29 @@
+.card {
+  @include flexbox(column, center, flex-start);
+  @include font-style('button1');
+
+  position: relative;
+  width: 791px;
+  padding: 24px 0 25px 35px;
+  border-radius: 20px;
+  background-color: $light-grey;
+}
+
+.nicknameChip {
+  @include flexbox(row, center, center);
+
+  position: absolute;
+  top: 24px;
+  right: 15px;
+  width: 100px;
+  height: 30px;
+  border: 0.75px solid $dark-grey;
+  border-radius: 37.58px;
+  @include font-style('text5');
+}
+
+.answerBox {
+  @include flexbox(column, center, center);
+
+  gap: 25px;
+}

--- a/components/descriptionCard/descriptionCard.stories.tsx
+++ b/components/descriptionCard/descriptionCard.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from '@storybook/react'
+
+import DescriptionCard from './descriptionCard'
+
+const meta: Meta<typeof DescriptionCard> = {
+  title: 'DescriptionCard',
+  component: DescriptionCard,
+}
+
+export default meta
+type Story = StoryObj<typeof DescriptionCard>
+
+export const WithNickname: Story = {
+  args: {
+    qa: [
+      { question: '질문 1', answer: '답변 1' },
+      { question: '질문 2', answer: '답변 2' },
+    ],
+    nickname: 'example',
+  },
+}
+
+export const WithoutNickname: Story = {
+  args: {
+    qa: [
+      { question: '질문 1', answer: '답변 1' },
+      { question: '질문 2', answer: '답변 2' },
+      { question: '질문 3', answer: '답변 3' },
+      { question: '질문 4', answer: '답변 4' },
+      { question: '질문 5', answer: '답변 5' },
+      { question: '질문 6', answer: '답변 6' },
+      { question: '질문 7', answer: '답변 7' },
+      { question: '질문 8', answer: '답변 8' },
+      { question: '질문 9', answer: '답변 9' },
+      { question: '질문 10', answer: '답변 10' },
+    ],
+  },
+}

--- a/components/descriptionCard/descriptionCard.stories.tsx
+++ b/components/descriptionCard/descriptionCard.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import DescriptionCard from './descriptionCard'
 
 const meta: Meta<typeof DescriptionCard> = {
-  title: 'DescriptionCard',
+  title: 'DescriptionCard/DescriptionCard',
   component: DescriptionCard,
 }
 

--- a/components/descriptionCard/descriptionCard.tsx
+++ b/components/descriptionCard/descriptionCard.tsx
@@ -1,0 +1,25 @@
+import classNames from 'classnames/bind'
+
+import styles from './descriptionCard.module.scss'
+import { DescriptionCardProps } from './descriptionCard.types'
+
+const cx = classNames.bind(styles)
+
+export default function DescriptionCard({
+  qa,
+  nickname,
+}: DescriptionCardProps) {
+  return (
+    <div className={cx('card')}>
+      {nickname && (
+        <div className={cx('nicknameChip')}>{`${nickname}님 작성`}</div>
+      )}
+      <div className={cx('answerBox')}>
+        {qa.map((pair, index) => (
+          // API 요청 시 질문과 답변이 각각 오므로, 질문과 답변을 조합하여 한 문장으로 만들어주는 helper 함수 구현 예정
+          <div key={index}>{pair.question}</div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/components/descriptionCard/descriptionCard.types.ts
+++ b/components/descriptionCard/descriptionCard.types.ts
@@ -1,0 +1,4 @@
+export interface DescriptionCardProps {
+  qa: Array<{ question: string; answer: string }>
+  nickname?: string
+}


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

<!-- 해당되는 사항만 남기고 나머지 줄을 삭제해주세요 -->

- FEAT : 새로운 기능 추가 및 개선

## 설명
마이페이지에 들어갈 카드 컴포넌트입니다.

### 이슈 번호

<!-- 키워드를 사용해 이슈를 연결해주세요 -->
<!-- 예시: close #1 / closes #1, #3 / resolve #4 -->
close #64 

### Key Changes

- 마이페이지에 들어갈 카드 컴포넌트를 구현했습니다.
- 모바일은 디자인을 좀 물어보고 확정되면 구현하겠습니다. (background, chip 배치 등등 정해져야 할 사항이 좀 있는 것 같습니다)

### How it Works

```
// DescriptionProp
interface DescriptionCardProps {
  qa: Array<{ question: string; answer: string }> // q-a 쌍이 있는 객체가 들어 있는 배열을 받습니다. (API 명세 참고했습니다)
  nickname?: string // 별명은 optional 하게 받습니다.
}
```

### To Reviewers

- story 작성하여 올렸습니다. 모양을 확인하고 혹시 잘못된 부분 있으면 comment 부탁드려요. (storybook은 font 적용이 안되나요...?)
