### PR TITLE
custom useFunnel 훅 구현

### DIFF
--- a/hooks/useFunnel.tsx
+++ b/hooks/useFunnel.tsx
@@ -1,4 +1,6 @@
-import { Children, ReactNode, isValidElement, useState } from 'react'
+import { Children, ReactNode, isValidElement, useEffect, useState } from 'react'
+
+import { usePathname, useRouter } from 'next/navigation'
 
 interface FunnelProps<T extends readonly string[]> {
   step: T[number]
@@ -59,7 +61,13 @@ export const useFunnel = <T extends readonly string[]>(
     (props: Omit<FunnelProps<T>, 'step'>) => <Funnel step={step} {...props} />,
     { Step: (props: StepProps<T>) => <Step<T> {...props} /> },
   )
+  const pathname = usePathname()
+  const router = useRouter()
+
+  useEffect(() => {
+    router.push(`${pathname}?step=${step}`)
+  }, [pathname, router, step])
 
   // FunnelElement와 현재 단계를 설정할 수 있는 setter를 튜플로 반환
-  return [FunnelElement, setStep] as const
+  return [FunnelElement, step, setStep] as const
 }

--- a/hooks/useFunnel.tsx
+++ b/hooks/useFunnel.tsx
@@ -1,6 +1,4 @@
-import { Children, ReactNode, isValidElement, useEffect, useState } from 'react'
-
-import { usePathname, useRouter } from 'next/navigation'
+import { Children, ReactNode, isValidElement, useState } from 'react'
 
 interface FunnelProps<T extends readonly string[]> {
   step: T[number]
@@ -61,13 +59,7 @@ export const useFunnel = <T extends readonly string[]>(
     (props: Omit<FunnelProps<T>, 'step'>) => <Funnel step={step} {...props} />,
     { Step: (props: StepProps<T>) => <Step<T> {...props} /> },
   )
-  const pathname = usePathname()
-  const router = useRouter()
-
-  useEffect(() => {
-    router.push(`${pathname}?step=${step}`)
-  }, [pathname, router, step])
 
   // FunnelElement와 현재 단계를 설정할 수 있는 setter를 튜플로 반환
-  return [FunnelElement, step, setStep] as const
+  return [FunnelElement, setStep] as const
 }

--- a/hooks/useFunnel.tsx
+++ b/hooks/useFunnel.tsx
@@ -1,0 +1,65 @@
+import { Children, ReactNode, isValidElement, useState } from 'react'
+
+interface FunnelProps<T extends readonly string[]> {
+  step: T[number]
+  children: ReactNode
+}
+
+interface StepProps<T extends readonly string[]> {
+  name: T[number]
+  children?: ReactNode
+}
+
+// 단계별로 컴포넌트를 렌더링해주는 Funnel 컴포넌트
+function Funnel<T extends readonly string[]>({
+  step,
+  children,
+}: FunnelProps<T>) {
+  // 유효한 자식 요소 필터링
+  const validElement = Children.toArray(children).filter(isValidElement)
+  // 현재 단계와 일치하는 Step 컴포넌트를 찾음
+  const targetElement = validElement.find(
+    (child) => (child.props as StepProps<T>)?.name === step,
+  )
+
+  // 일치하는 Step 컴포넌트가 없으면 null 반환
+  if (!targetElement) {
+    return null
+  }
+
+  return <>{targetElement}</>
+}
+
+// 단순히 자식 요소들을 렌더링해주는 Step 컴포넌트
+function Step<T extends readonly string[]>({ children }: StepProps<T>) {
+  return <>{children}</>
+}
+
+/**
+ * Funnel 컴포넌트와 현재 단계를 설정할 수 있는 setter를 포함하는 튜플을 반환하는 훅
+ * @param {T} steps - Funnel의 사용 가능한 단계 배열
+ * @param {T[number]} defaultStep - 시작 기본 단계
+ * @returns {[typeof Funnel, React.Dispatch<React.SetStateAction<T[number]>>]}
+ * Funnel 요소와 현재 단계를 설정할 수 있는 setter를 포함하는 튜플을 반환한다.
+ * @example
+ * const steps = ['Step1', 'Step2', 'Step3'] as const;
+ * const defaultStep = 'Step1';
+ * const [FunnelElement, setStep] = useFunnel(steps, defaultStep);
+ * // FunnelElement를 JSX로 렌더링하고, setStep을 사용하여 현재 단계를 변경할 수 있다.
+ */
+
+export const useFunnel = <T extends readonly string[]>(
+  steps: T,
+  defaultStep: T[number],
+) => {
+  const [step, setStep] = useState(defaultStep)
+
+  // Funnel 컴포넌트와 함께 Step 컴포넌트를 반환하는 객체를 생성
+  const FunnelElement = Object.assign(
+    (props: Omit<FunnelProps<T>, 'step'>) => <Funnel step={step} {...props} />,
+    { Step: (props: StepProps<T>) => <Step<T> {...props} /> },
+  )
+
+  // FunnelElement와 현재 단계를 설정할 수 있는 setter를 튜플로 반환
+  return [FunnelElement, setStep] as const
+}


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

<!-- 해당되는 사항만 남기고 나머지 줄을 삭제해주세요 -->

- FEAT : 새로운 기능 추가 및 개선

## 설명
next.js에서 사용가능한 useFunnel 훅 구현


### 이슈 번호

<!-- 키워드를 사용해 이슈를 연결해주세요 -->
<!-- 예시: close #1 / closes #1, #3 / resolve #4 -->
close #92


### Key Changes

- useFunnel 구현


### How it Works

<img width="492" alt="image" src="https://github.com/najasin/na-jasin-fe/assets/81355590/eb9605e1-24d9-4bd0-b66e-68141aaab094">
js doc 참고해서 useFunnel 훅 사용한 후, jsx 사진처럼 작성하면 됩니다.


### To Reviewers
- app router 13부터 shallow routing이 안되더라구요. 그래서 router.push를 하긴 했는데, 그러면 전체 렌더링이 됩니다. 해결책 같이 찾아보면 좋을 것 같아요
   - [블로그처럼](https://medium.com/@moh.mir36/shallow-routing-with-next-js-v13-app-directory-2d765928c340) 했는데 이상해지길래 일단은 보류했습니다.
 