### PR TITLE
radar chart container setter prop 추가

### DIFF
--- a/components/radarChart/radarChart.types.ts
+++ b/components/radarChart/radarChart.types.ts
@@ -1,3 +1,5 @@
+import { Dispatch, SetStateAction } from 'react'
+
 interface DataPoint {
   axis: string
   value: number
@@ -47,6 +49,7 @@ interface IRadarChartContainerProps {
   radarSize: number
   framePadding: number
   hasOthers: boolean
+  setRadarData?: Dispatch<SetStateAction<IAxisMaps[] | null>>
 }
 
 export type {

--- a/components/radarChart/radarChartContainer.tsx
+++ b/components/radarChart/radarChartContainer.tsx
@@ -27,6 +27,7 @@ export default function RadarChartContainer({
   radarSize,
   framePadding,
   hasOthers,
+  setRadarData,
 }: IRadarChartContainerProps) {
   const bubbleVariants = {
     opened: {
@@ -159,8 +160,9 @@ export default function RadarChartContainer({
   }
 
   useEffect(() => {
-    // POST request { userGenerated }
-  }, [userGenerated])
+    if (!setRadarData) return
+    setRadarData(userGenerated)
+  }, [userGenerated, setRadarData])
 
   return (
     <div className={cx('radarChartContainerWrapper')}>

--- a/components/radarChart/radarChartFetcher.tsx
+++ b/components/radarChart/radarChartFetcher.tsx
@@ -1,5 +1,8 @@
 'use client'
 
+import { useEffect, useState } from 'react'
+
+import { IAxisMaps } from './radarChart.types'
 // import { useQuery } from '@tanstack/react-query'
 // import { getRadarData } from './radar-mock.apis'
 import RadarChartContainer from './radarChartContainer'
@@ -93,6 +96,13 @@ export default function RadarChartFetcher({
     radarSize: 200,
   }
 
+  const [radarData, setRadarData] = useState<IAxisMaps[] | null>(null)
+
+  useEffect(() => {
+    // example
+    // console.log(radarData)
+  }, [radarData])
+
   return (
     <RadarChartContainer
       radarType={radarType}
@@ -102,6 +112,7 @@ export default function RadarChartFetcher({
       radarSize={rectangleLayout.radarSize}
       framePadding={rectangleLayout.frameSize - rectangleLayout.radarSize}
       hasOthers={hasOthers}
+      setRadarData={setRadarData}
     />
   )
 }


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

<!-- 해당되는 사항만 남기고 나머지 줄을 삭제해주세요 -->

- FIX : 버그 수정

## 설명

- radar 사용할 때는 radarChartContainer 사용하면 됩니다. 
  - 사용 예시는 radarChartFethcer에서 확인할 수 있습니다. 
  - 넘겨줄 prop 예시는 스토리북에서 자세하게 확인할 수 있습니다. 
  - frameSize, radarSize, framePadding은 Fetcher에 작성된 대로 350, 200, frameSize - radarSize로 고정하면 됩니다. 만약에 반응형에서 뭔가 깨진다 싶으면 말해주세요
- 등록하기(나적나사, 타적나사)의 경우 변경된 데이터를 받기 위해 setState를 radarChartContainer에 넘겨줄 수 있습니다.  


### 이슈 번호

<!-- 키워드를 사용해 이슈를 연결해주세요 -->
<!-- 예시: close #1 / closes #1, #3 / resolve #4 -->

close #118 
