### PR TITLE
소셜 인증 로직 구현 및 미들웨어 쿠키 주입 적용 

### DIFF
--- a/api/axios/common.apis.ts
+++ b/api/axios/common.apis.ts
@@ -13,7 +13,7 @@ export const getRequest = async <T>(
     url,
     config as InternalAxiosRequestConfig,
   )
-  return response.data
+  return response.data.data
 }
 
 // /* post 요청 */
@@ -27,7 +27,7 @@ export const postRequest = async <T>(
     data,
     config as InternalAxiosRequestConfig,
   )
-  return response.data
+  return response.data.data
 }
 
 /* delete 요청 */
@@ -39,7 +39,7 @@ export const deleteRequest = async <T>(
     url,
     config as InternalAxiosRequestConfig,
   )
-  return response.data
+  return response.data.data
 }
 
 /* put 요청 */
@@ -53,7 +53,7 @@ export const putRequest = async <T>(
     data,
     config as InternalAxiosRequestConfig,
   )
-  return response.data
+  return response.data.data
 }
 
 /* patch 요청 */
@@ -67,5 +67,5 @@ export const patchRequest = async <T>(
     data,
     config as InternalAxiosRequestConfig,
   )
-  return response.data
+  return response.data.data
 }

--- a/api/axios/instance/instance.apis.ts
+++ b/api/axios/instance/instance.apis.ts
@@ -4,19 +4,18 @@ import axios, {
   AxiosResponse,
   InternalAxiosRequestConfig,
 } from 'axios'
+import { getCookie } from 'cookies-next'
 
 import { logOnDev } from './instance.helpers'
 import { CustomAxiosInterface } from './instance.types'
 
 export const instance: CustomAxiosInterface = axios.create({
-  baseURL:
-    process.env.NODE_ENV === 'development'
-      ? 'http://localhost:3000'
-      : process.env.NEXT_PUBLIC_BASE_URL,
+  baseURL: process.env.NEXT_PUBLIC_BASE_URL,
   headers: {
     'Content-Type': 'application/json',
     Accept: '*/*',
   },
+  withCredentials: true,
   timeout: 30000,
 })
 
@@ -26,16 +25,14 @@ instance.interceptors.request.use(
     /**
      * request 직전 공통으로 진행할 작업
      */
+    if (config && config.headers) {
+      const act = getCookie('act')
+      // const rft = getCookie('rft')
 
-    // if (config && config.headers) {
-    //   const token = getCookie('token')
-
-    //   // 인증할 때 받은 토큰을 쿠키에 저장했다면 가져옵니다.
-    //   if (token) {
-    //     config.headers.Authorization = `Bearer ${token}`
-    //     config.headers['Content-Type'] = 'application/json'
-    //   }
-    // }
+      if (act) {
+        config.headers.Authorization = act
+      }
+    }
 
     if (process.env.NODE_ENV === 'development') {
       const { method, url } = config

--- a/api/axios/instance/instance.types.ts
+++ b/api/axios/instance/instance.types.ts
@@ -40,7 +40,9 @@ interface CustomAxiosInterface extends AxiosInstance {
 
 /* common */
 interface CommonResponse<T> {
-  data: T
+  data: {
+    data: T
+  }
   status: number
   statusText: string
 }

--- a/components/signIn/signinSocialContainer.tsx
+++ b/components/signIn/signinSocialContainer.tsx
@@ -4,6 +4,7 @@ import classNames from 'classnames/bind'
 import { motion } from 'framer-motion'
 
 import Image from 'next/image'
+import { useRouter } from 'next/navigation'
 
 import styles from './signIn.module.scss'
 
@@ -14,8 +15,15 @@ export default function SigninSocialContainer({
 }: {
   userType: 'forFun' | 'forDev'
 }) {
-  const handleClickGetAuthenticationCodeKaKao = () => {}
-  const handleClickGetAuthenticationCodeGoogle = () => {}
+  const router = useRouter()
+  const handleClickGetAuthenticationCodeKaKao = () => {
+    router.push(`${process.env.NEXT_PUBLIC_BASE_URL}/auth2/authorize/kakao`)
+  }
+
+  const handleClickGetAuthenticationCodeGoogle = () => {
+    router.push(`${process.env.NEXT_PUBLIC_BASE_URL}/auth2/authorize/google`)
+  }
+
   const handleClickGetAuthenticationCodeGithub = () => {}
 
   return (

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+export function middleware(req: NextRequest) {
+  const { pathname, searchParams } = req.nextUrl
+
+  if (
+    pathname.startsWith('/') &&
+    pathname.endsWith('/') &&
+    searchParams.get('accessToken')
+  ) {
+    const act = searchParams.get('accessToken')
+    const rft = searchParams.get('refreshToken')
+    // const uid = searchParams.get('userId')
+    // const userType = searchParams.get('userType')
+
+    const response = NextResponse.redirect(new URL('/jff/my-manual', req.url))
+
+    response.cookies.set({
+      name: 'act',
+      value: act as string,
+      //   httpOnly: true,
+      secure: true,
+      sameSite: 'none',
+    })
+    response.cookies.set({
+      name: 'rft',
+      value: rft as string,
+      //   httpOnly: true,
+      secure: true,
+      sameSite: 'none',
+    })
+
+    return response
+  }
+
+  return NextResponse.next()
+}

--- a/next.config.js
+++ b/next.config.js
@@ -1,13 +1,5 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  async rewrites() {
-    return [
-      {
-        source: '/:path*',
-        destination: 'https://api.na-jasin.com/:path*',
-      },
-    ]
-  },
   sassOptions: {
     prependData:
       '@use "styles/_utils.scss" as *; @use "styles/_mixin.scss" as *;',


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

<!-- 해당되는 사항만 남기고 나머지 줄을 삭제해주세요 -->

- FEAT : 새로운 기능 추가 및 개선
- FIX : 버그 수정
- REFACTOR : 결과의 변경 없이 코드의 구조를 재조정

## 설명

- 소셜 로그인 버튼을 누르고 받은 데이터를 미들웨어에서 처리합니다. (일단 무조건 jff/my-manual로 갑니다)
- 인터셉터에서 쿠키의 토큰을 가져와 authorization에 등록해뒀습니다. 클라이언트면 그냥 쏘면 되고, 서버 컴포넌트면 별도로 쿠키 주입해야 합니다. 이것도 미들웨어에서 처리할 수 있는지 찾아보고는 있는데, 일단은 서버 컴포넌트면 직접 주입해야 합니다.
- 현재 로그인하면 무조건 등록하기로 가는데 다른 페이지를 막아두지 않아서 그냥 url에 본인 페이지 입력해서 들어가면 됩니다. 

### 이슈 번호

<!-- 키워드를 사용해 이슈를 연결해주세요 -->
<!-- 예시: close #1 / closes #1, #3 / resolve #4 -->

close #132 #174 
