### PR TITLE
FAB 떠다니는 애니메이션 + 버튼 우하단 그림자 구현

### DIFF
--- a/components/fab/circleButton.module.scss
+++ b/components/fab/circleButton.module.scss
@@ -8,6 +8,8 @@
   @include mobile {
     @include font-style('button6');
   }
+
+  box-shadow: 5px 5px 8px rgb(0 0 0 / 20%);
 }
 
 .sm {

--- a/components/fab/circleButton.module.scss
+++ b/components/fab/circleButton.module.scss
@@ -65,6 +65,14 @@
   color: $blue-point;
 }
 
+.action {
+  transition: transform 0.3s ease-in-out;
+
+  &:hover {
+    transform: scale(1.05); // Slightly bigger on hover
+  }
+}
+
 .facebookImg,
 .kakaoImg,
 .instagramImg,

--- a/components/fab/circleButton.tsx
+++ b/components/fab/circleButton.tsx
@@ -15,6 +15,7 @@ export default function CircleButton({
   size = 'md',
   image,
   text,
+  action,
   transparent,
   onClick,
 }: CircleButtonProps) {
@@ -22,7 +23,14 @@ export default function CircleButton({
 
   return (
     <button
-      className={cx('circleBtn', size, image, name, transparent && 'blank')}
+      className={cx(
+        'circleBtn',
+        size,
+        image,
+        name,
+        action && 'action',
+        transparent && 'blank',
+      )}
       onClick={onClick}
     >
       {text && <p>{text}</p>}

--- a/components/fab/circleButton.types.ts
+++ b/components/fab/circleButton.types.ts
@@ -3,6 +3,7 @@ export interface CircleButtonProps {
   size: 'sm' | 'md' | 'lg'
   image?: string
   text?: string
+  action?: boolean
   transparent?: boolean
   onClick?: () => void
 }

--- a/components/fab/fab.module.scss
+++ b/components/fab/fab.module.scss
@@ -76,3 +76,18 @@
     @include position(9px, 150px);
   }
 }
+
+.baseBtn {
+  animation: floating 2s infinite ease-in-out;
+}
+
+@keyframes floating {
+  0%,
+  100% {
+    transform: translateY(0); // Start and end position
+  }
+
+  50% {
+    transform: translateY(-10px); // Peak position
+  }
+}

--- a/components/fab/fab.tsx
+++ b/components/fab/fab.tsx
@@ -53,12 +53,14 @@ export default function Fab() {
         animate={{ rotate: isClicked ? 45 : 0 }}
         className={cx('basic')}
       >
-        <CircleButton
-          name="plus"
-          size="lg"
-          image="plus"
-          onClick={handleClick}
-        />
+        <div className={cx(!isClicked && 'baseBtn')}>
+          <CircleButton
+            name="plus"
+            size="lg"
+            image="plus"
+            onClick={handleClick}
+          />
+        </div>
       </motion.div>
     </div>
   )

--- a/components/fab/fab.tsx
+++ b/components/fab/fab.tsx
@@ -29,16 +29,31 @@ export default function Fab() {
         >
           <div>
             <div className={cx('absolute', 'facebook')}>
-              <CircleButton name="facebook" image="facebook" size="sm" />
+              <CircleButton
+                name="facebook"
+                image="facebook"
+                size="sm"
+                action={true}
+              />
             </div>
             <div className={cx('absolute', 'kakao')}>
-              <CircleButton name="kakao" image="kakao" size="sm" />
+              <CircleButton
+                name="kakao"
+                image="kakao"
+                size="sm"
+                action={true}
+              />
             </div>
             <div className={cx('absolute', 'instagram')}>
-              <CircleButton name="instagram" image="instagram" size="sm" />
+              <CircleButton
+                name="instagram"
+                image="instagram"
+                size="sm"
+                action={true}
+              />
             </div>
             <div className={cx('absolute', 'link')}>
-              <CircleButton name="link" image="link" size="sm" />
+              <CircleButton name="link" image="link" size="sm" action={true} />
             </div>
           </div>
           <CircleButton
@@ -58,6 +73,7 @@ export default function Fab() {
             name="plus"
             size="lg"
             image="plus"
+            action={true}
             onClick={handleClick}
           />
         </div>

--- a/components/fab/fabForDf.module.scss
+++ b/components/fab/fabForDf.module.scss
@@ -70,3 +70,18 @@
     @include position(11px, 215px);
   }
 }
+
+.baseBtn {
+  animation: floating 2s infinite ease-in-out;
+}
+
+@keyframes floating {
+  0%,
+  100% {
+    transform: translateY(0); // Start and end position
+  }
+
+  50% {
+    transform: translateY(-10px); // Peak position
+  }
+}

--- a/components/fab/fabForDf.tsx
+++ b/components/fab/fabForDf.tsx
@@ -27,16 +27,31 @@ export default function FabWithDef() {
         >
           <div>
             <div className={cx('absolute', 'facebook')}>
-              <CircleButton name="facebook" image="facebook" size="sm" />
+              <CircleButton
+                name="facebook"
+                image="facebook"
+                size="sm"
+                action={true}
+              />
             </div>
             <div className={cx('absolute', 'kakao')}>
-              <CircleButton name="kakao" image="kakao" size="sm" />
+              <CircleButton
+                name="kakao"
+                image="kakao"
+                size="sm"
+                action={true}
+              />
             </div>
             <div className={cx('absolute', 'instagram')}>
-              <CircleButton name="instagram" image="instagram" size="sm" />
+              <CircleButton
+                name="instagram"
+                image="instagram"
+                size="sm"
+                action={true}
+              />
             </div>
             <div className={cx('absolute', 'link')}>
-              <CircleButton name="link" image="link" size="sm" />
+              <CircleButton name="link" image="link" size="sm" action={true} />
             </div>
           </div>
           <div className={cx('mdButtons')}>
@@ -50,6 +65,7 @@ export default function FabWithDef() {
               name="weakness"
               text="단점보기"
               transparent={true}
+              action={true}
               size="md"
             />
           </div>
@@ -64,6 +80,7 @@ export default function FabWithDef() {
             name="plus"
             size="lg"
             image="plus"
+            action={true}
             onClick={handleClick}
           />
         </div>

--- a/components/fab/fabForDf.tsx
+++ b/components/fab/fabForDf.tsx
@@ -59,12 +59,14 @@ export default function FabWithDef() {
         animate={{ rotate: isClicked ? 45 : 0 }}
         className={cx('basic')}
       >
-        <CircleButton
-          name="plus"
-          size="lg"
-          image="plus"
-          onClick={handleClick}
-        />
+        <div className={cx('baseBtn')}>
+          <CircleButton
+            name="plus"
+            size="lg"
+            image="plus"
+            onClick={handleClick}
+          />
+        </div>
       </motion.div>
     </div>
   )

--- a/components/fab/fabForDf.tsx
+++ b/components/fab/fabForDf.tsx
@@ -75,7 +75,7 @@ export default function FabWithDef() {
         animate={{ rotate: isClicked ? 45 : 0 }}
         className={cx('basic')}
       >
-        <div className={cx('baseBtn')}>
+        <div className={cx(!isClicked && 'baseBtn')}>
           <CircleButton
             name="plus"
             size="lg"


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

<!-- 해당되는 사항만 남기고 나머지 줄을 삭제해주세요 -->

- FEAT : 새로운 기능 추가 및 개선

## 설명
FAB 떠다니는 애니메이션 + 버튼 우하단 그림자 구현 PR입니다.


### 이슈 번호

<!-- 키워드를 사용해 이슈를 연결해주세요 -->
<!-- 예시: close #1 / closes #1, #3 / resolve #4 -->
close #183 


### Key Changes

- JFF / DF FAB 모두에 애니메이션 추가
- CircleButton에 그림자 추가


### How it Works

- 간단한 로직 설명


### To Reviewers

- storybook으로 확인할 수 있습니다. 애니메이션 속도 먼저 확인해 주세요
- 이 PR open 해 두고 기타 애니메이션 붙이겠습니다.
