### PR TITLE
isOwner 값에 따라 EditBtn 렌더링 로직 추가

### DIFF
--- a/app/(main)/[userType]/my-page/page.tsx
+++ b/app/(main)/[userType]/my-page/page.tsx
@@ -47,6 +47,7 @@ export default async function MyPage({
       othersManualQAPairs,
       originKeywordPercents,
       otherKeywordPercents,
+      isOwner,
     } = data
 
     const characterData = {
@@ -66,10 +67,12 @@ export default async function MyPage({
               othersKeywordPercents={otherKeywordPercents}
               data={characterData}
               nickname={nickname}
+              isOwner={isOwner}
             />
             <ManualBox
               myDatas={myManualQAPair}
               othersDatas={othersManualQAPairs}
+              isOwner={isOwner}
             />
           </ContentWrapper>
         </SimpleLayout>

--- a/components/manualBox/manualBox.tsx
+++ b/components/manualBox/manualBox.tsx
@@ -26,7 +26,11 @@ import styles from './manualBox.module.scss'
 
 const cx = classNames.bind(styles)
 
-export default function ManualBox({ myDatas, othersDatas }: IManualBoxProps) {
+export default function ManualBox({
+  myDatas,
+  othersDatas,
+  isOwner,
+}: IManualBoxProps) {
   const otherAnswers = othersDatas.map((data) => {
     const { nickname, qas } = data
     const datas = qas.map((qa) => {
@@ -110,7 +114,7 @@ export default function ManualBox({ myDatas, othersDatas }: IManualBoxProps) {
         <div className={cx('manual')}>
           <div className={cx('header')}>
             <p>자시니는 이렇게 사용해요</p>
-            {descriptionType === 'MY' && (
+            {descriptionType === 'MY' && isOwner && (
               <EditBtn onClick={handleClickModalOpen} />
             )}
           </div>

--- a/components/manualBox/manualBox.types.ts
+++ b/components/manualBox/manualBox.types.ts
@@ -8,6 +8,7 @@ export interface IManualBoxProps {
     nickname: string
     qas: Array<{ id: number; question: string; answer: string }>
   }>
+  isOwner: boolean
 }
 
 export interface IFormData {

--- a/components/profileBox/profileBox.tsx
+++ b/components/profileBox/profileBox.tsx
@@ -42,6 +42,7 @@ export default function ProfileBox({
   data,
   myKeywordPercents,
   othersKeywordPercents,
+  isOwner,
 }: IProfileBoxProps) {
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false)
 
@@ -146,7 +147,7 @@ export default function ProfileBox({
           <CharacterBox
             baseImage={data?.baseImage}
             selectedItems={characterItems}
-            editBtn={<EditBtn onClick={handleClickModalOpen} />}
+            editBtn={isOwner && <EditBtn onClick={handleClickModalOpen} />}
             nickname={nickname}
           />
         </div>

--- a/components/profileBox/profileBox.types.ts
+++ b/components/profileBox/profileBox.types.ts
@@ -27,4 +27,5 @@ export interface IProfileBoxProps {
   }
   myKeywordPercents: { [key: string]: number }
   othersKeywordPercents: { [key: string]: number }
+  isOwner: boolean
 }


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

<!-- 해당되는 사항만 남기고 나머지 줄을 삭제해주세요 -->

- FEAT : 새로운 기능 추가 및 개선

## 설명
새로운 isOwner 데이터를 활용하여 편집 버튼의 조건부 렌더링 로직을 추가하였습니다.


### 이슈 번호

<!-- 키워드를 사용해 이슈를 연결해주세요 -->
<!-- 예시: close #1 / closes #1, #3 / resolve #4 -->
close #199


### Key Changes

- page에서 데이터 받기
- ProfileBox prop type, prop 수정, 렌더링 로직 추가
- ManualBox prop type, prop 수정, 렌더링 로직 추가


### How it Works

- isOwner가 `true` 일 경우만 편집 버튼을 보여줍니다.


### To Reviewers
