### PR TITLE
마이페이지 token 없을 경우 데이터 불러오는 함수 수정

### DIFF
--- a/api/axios/requestHandler/mypage/get.apis.ts
+++ b/api/axios/requestHandler/mypage/get.apis.ts
@@ -21,15 +21,13 @@ const getMypage = async ({
 }: {
   userType: string
   userId: string
-  token: string | undefined
+  token?: string
 }): Promise<IMyPageDatas> => {
+  const config = token ? { headers: { Authorization: `${token}` } } : {}
+
   const response = await getRequest<IMyPageDatas>(
     `/api/user/${userType}/mypage?userId=${userId}`,
-    {
-      headers: {
-        Authorization: `${token}`,
-      },
-    },
+    config
   )
 
   return response

--- a/app/(main)/[userType]/my-page/page.tsx
+++ b/app/(main)/[userType]/my-page/page.tsx
@@ -12,7 +12,7 @@ import { getMypage } from '@/api/axios/requestHandler/mypage/get.apis'
 const getMyPageData = async (
   userType: string,
   userId: string,
-  token: string | undefined,
+  token?: string,
 ) => {
   try {
     const data = await getMypage({ userType, userId, token })


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

<!-- 해당되는 사항만 남기고 나머지 줄을 삭제해주세요 -->

- FIX : 버그 수정

## 설명
getMyPage 함수를 수정하였습니다


### 이슈 번호

<!-- 키워드를 사용해 이슈를 연결해주세요 -->
<!-- 예시: close #1 / closes #1, #3 / resolve #4 -->
close #244 


### Key Changes

- getRequest 파라미터 config에 조건부로 Authorization 또는 빈 객체를 넣어줍니다.


### How it Works
```
const getMypage = async ({
  userType,
  userId,
  token,
}: {
  userType: string
  userId: string
  token?: string
}): Promise<IMyPageDatas> => {
  const config = token ? { headers: { Authorization: `${token}` } } : {} // 토큰 유무에 따라 config 달라지도록

  const response = await getRequest<IMyPageDatas>(
    `/api/user/${userType}/mypage?userId=${userId}`,
    config
  )

  return response
}
```


### To Reviewers
