### PR TITLE
404 page height 수정

### DIFF
--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,5 +1,5 @@
 import ErrorComponent from '@/components/error/error'
 
 export default function NotFound() {
-  return <ErrorComponent variant="error" />
+  return <ErrorComponent />
 }

--- a/components/error/error.module.scss
+++ b/components/error/error.module.scss
@@ -1,5 +1,4 @@
 .wrap {
-  height: 80vh;
   margin: 50px auto;
   text-align: center;
 


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

<!-- 해당되는 사항만 남기고 나머지 줄을 삭제해주세요 -->

- FIX : 버그 수정

## 설명
![image](https://github.com/najasin/na-jasin-fe/assets/81355590/29d961a5-d220-4ade-85ea-7f19bae177cf)
404/에러 페이지 height 낮아졌을 때 콘텐츠 넘치는 거 수정


### 이슈 번호
close #275 

<!-- 키워드를 사용해 이슈를 연결해주세요 -->
<!-- 예시: close #1 / closes #1, #3 / resolve #4 -->



### Key Changes

- 404/에러 페이지 height 낮아졌을 때 콘텐츠 넘치는 거 수정


### How it Works

- 404일때는 varaint 404, error일 때는 error


### To Reviewers

-content가 작아지면 footer가 올라오는데, 전체 페이지에서 스타일링 다시해야 할 것 같습니다. footer는 fixed를 줘서 바닥에 붙어있거나, content의 min-height을 100vh로 하면 될 것 같습니다. 
